### PR TITLE
fix never-dropping sse issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,14 +90,13 @@ dependencies = [
 [[package]]
 name = "async-sse"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff0a3074c2c3cfd76417f6e03d5c99822d3ef37387af891e4a8bf46447ca870"
+source = "git+https://github.com/jbr/async-sse?branch=handle-dropped-encoder#d2f1aa648864d7fd952c801e6f7d513446b4a15b"
 dependencies = [
  "async-std",
  "http-types",
  "log",
  "memchr",
- "pin-project-lite",
+ "pin-project",
 ]
 
 [[package]]
@@ -619,18 +618,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75373ff9037d112bb19bc61333a06a159eaeb217660dcfbea7d88e1db823919"
+checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b4b44893d3c370407a1d6a5cfde7c41ae0478e31c516c85f67eb3adc51be6d"
+checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1006,8 +1005,7 @@ dependencies = [
 [[package]]
 name = "tide"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151b07f369a9152c2f93715ea0db8a7f7e2533bd2e52fbff1ea5bad7a88db541"
+source = "git+https://github.com/jbr/tide?branch=handle-dropped-sse-encoder#276c5efc2638f14f5ab3324d66e9496b73a5334a"
 dependencies = [
  "async-h1",
  "async-sse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tide = "0.11.0"
+tide = { git = "https://github.com/jbr/tide", branch = "handle-dropped-sse-encoder" }
 async-std = { version = "1.6.1", features = ["attributes"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ async fn main() {
 
             loop {
                 println!("[{}] Sending...", pod.n);
-                sender.send("hello", "world", None).await;
+                sender.send("hello", "world", None).await?;
                 println!("[{}] Sent!", pod.n);
                 task::sleep(Duration::from_secs(1)).await;
             }


### PR DESCRIPTION
Please confirm this works as you'd expect. The issue was that there was previously no reason for the sender task loop to end, so it never dropped. This change still requires the calling code to check for disconnected clients, but using `?` hopefully makes that fairly painless